### PR TITLE
Remove contract function from ApeSafe, since it overrides Safe's contract function 

### DIFF
--- a/ape_safe.py
+++ b/ape_safe.py
@@ -66,6 +66,7 @@ class ApeSafe(Safe):
         self.base_url = base_url or transaction_service[chain.id]
         self.multisend = multisend or multisends.get(chain.id, MULTISEND_CALL_ONLY)
         super().__init__(address, ethereum_client)
+        super().contract  # `contract` is a cached property of Safe
 
     def __str__(self):
         return EthAddress(self.address)
@@ -79,15 +80,6 @@ class ApeSafe(Safe):
         Unlocked Brownie account for Gnosis Safe.
         """
         return accounts.at(self.address, force=True)
-
-    def contract(self, address=None) -> Contract:
-        """
-        Instantiate a Brownie Contract owned by Safe account.
-        """
-        if address:
-            address = to_checksum_address(address) if is_address(address) else web3.ens.resolve(address)
-            return Contract(address, owner=self.account)
-        return Safe.contract if hasattr(Safe, 'contract') else Safe.get_contract
 
     def pending_nonce(self) -> int:
         """

--- a/ape_safe.py
+++ b/ape_safe.py
@@ -66,7 +66,6 @@ class ApeSafe(Safe):
         self.base_url = base_url or transaction_service[chain.id]
         self.multisend = multisend or multisends.get(chain.id, MULTISEND_CALL_ONLY)
         super().__init__(address, ethereum_client)
-        super().contract  # `contract` is a cached property of Safe
 
     def __str__(self):
         return EthAddress(self.address)


### PR DESCRIPTION
Since Safe has changed from `get_contract` to `contract`, ApeSafe's `contract` overrides it. This same issue was worked on in https://github.com/banteg/ape-safe/pull/48. But apparently some bugs persist.

Consider the following minimal example:
```
from ape_safe import ApeSafe
from brownie import Contract

def main():
    safe = ApeSafe('ychad.eth')
    dai = safe.contract('0xDaiAddress')
    dai.transfer(safe.address, 1e18)
    dai.transfer(safe.address, 1e18)
    safe_tx = safe.multisend_from_receipts()
    safe.sign_transaction(safe_tx)
    safe.post_transaction(safe_tx)
```
```
brownie run example.py --network goerli-fork
```

This errors out and with the following stack trace:
```
  File "brownie/_cli/run.py", line 51, in main
    return_value, frame = run(
  File "brownie/project/scripts.py", line 110, in run
    return_value = f_locals[method_name](*args, **kwargs)
  File "./check2.py", line 12, in main
    safe_tx = safe.multisend_from_receipts()
  File "ape_safe.py", line 122, in multisend_from_receipts
    return self.build_multisig_tx(self.multisend, 0, data, SafeOperation.DELEGATE_CALL.value, safe_nonce=safe_nonce)
  File "gnosis/safe/safe.py", line 1095, in build_multisig_tx
    safe_version = safe_version or self.retrieve_version()
  File "gnosis/safe/safe.py", line 1056, in retrieve_version
    return self.contract.functions.VERSION().call(block_identifier=block_identifier)
AttributeError: 'function' object has no attribute 'functions'
```

Since ApeSafe's `contract` has overridden Safe's `contract`, `contract` is being regarded as a 'function' object and not a cached property which has a functions attribute (https://github.com/safe-global/safe-eth-py/blob/5f016ce15aae3ac699a57f85de5d583a4f6341e0/gnosis/safe/safe.py#L111).

I don't see how to avoid this overriding, so there are two possible solutions:
1. Remove ApeSafe's `contract` function
2. Change the name of ApeSafe's `contract` function to something else

I chose option 1 since the `contract` function of ApeSafe doesn't serve a critical purpose. All it does is make the safe the default sender of transactions to the input contract. This is not such a big functionality since simply using brownie's syntax to specify the sender is easy enough and used for all brownie code anyway.
```
dai = Contract('0xDaiAddress')
dai.transfer(safe.address, 1e18, {'from': safe.account})
```