### PR TITLE
fix: custom multisend check needs to cast to enum

### DIFF
--- a/brownie_safe.py
+++ b/brownie_safe.py
@@ -108,7 +108,7 @@ class BrownieSafe(Safe):
         address = to_checksum_address(address) if is_address(address) else web3.ens.resolve(address)
         ethereum_client = EthereumClient(web3.provider.endpoint_uri)
         self.transaction_service = TransactionServiceBackport(ethereum_client.get_network(), ethereum_client, base_url)
-        self.multisend = multisend or CUSTOM_MULTISENDS.get(chain.id, DEFAULT_MULTISEND_CALL_ONLY)
+        self.multisend = multisend or CUSTOM_MULTISENDS.get(EthereumNetworkBackport(chain.id), DEFAULT_MULTISEND_CALL_ONLY)
         super().__init__(address, ethereum_client)
         if self.client == 'anvil':
             web3.manager.request_blocking('anvil_setNextBlockBaseFeePerGas', ['0x0'])


### PR DESCRIPTION
We always hit the default value in aby `CUSTOM_MULTISENDS.get()` call since `chain.id` is an integer and `CUSTOM_MULTISENDS` contains `EthereumNetworkBackport` enum types. This fixes the issue by creating an enum from chain.id before the call to get.