### PR TITLE
fix: transactions endpoint

### DIFF
--- a/brownie_safe.py
+++ b/brownie_safe.py
@@ -292,7 +292,7 @@ class BrownieSafe(Safe):
         """
         Retrieve pending transactions from the transaction service.
         """
-        results = self.transaction_service._get_request(f'/api/v1/safes/{self.address}/transactions/').json()['results']
+        results = self.transaction_service._get_request(f'/api/v1/safes/{self.address}/multisig-transactions/').json()['results']
         nonce = self.retrieve_nonce()
         transactions = [
             self.build_multisig_tx(


### PR DESCRIPTION
Recently the `transactions` endpoint of the transactions service got removed in favor of `multisig-transactions`, see [here](https://github.com/safe-global/safe-transaction-service/pull/2048).