### PR TITLE
feat: contract wrapper amendments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 env/
 .python-version
 scripts/
+__pycache__/

--- a/brownie_safe.py
+++ b/brownie_safe.py
@@ -359,7 +359,7 @@ class BrownieSafe:
             slot = int.from_bytes(keccak(tx.safe_tx_hash + outer_key), 'big')
             self.set_storage(tx.safe_address, slot, 1)
 
-        payload = tx.w3_tx.buildTransaction()
+        payload = tx.w3_tx.build_transaction()
         receipt = owners[0].transfer(payload['to'], payload['value'], gas_limit=payload['gas'], data=payload['data'])
 
         if 'ExecutionSuccess' not in receipt.events:
@@ -387,7 +387,7 @@ class BrownieSafe:
         """
         Execute a fully signed transaction likely retrieved from the pending_transactions method.
         """
-        payload = safe_tx.w3_tx.buildTransaction()
+        payload = safe_tx.w3_tx.build_transaction()
         signer = self.get_signer(signer)
         receipt = signer.transfer(payload['to'], payload['value'], gas_limit=payload['gas'], data=payload['data'])
         return receipt
@@ -400,7 +400,7 @@ class BrownieSafe:
         frame = Web3(Web3.HTTPProvider(frame_rpc, {'timeout': 600}))
         account = frame.eth.accounts[0]
         frame.manager.request_blocking('wallet_switchEthereumChain', [{'chainId': hex(chain.id)}])
-        payload = safe_tx.w3_tx.buildTransaction()
+        payload = safe_tx.w3_tx.build_transaction()
         tx = {
             "from": account,
             "to": self.address,

--- a/brownie_safe.py
+++ b/brownie_safe.py
@@ -340,7 +340,7 @@ class BrownieSafe:
 
     def preview_tx(self, safe_tx: SafeTx, events=True, call_trace=False) -> TransactionReceipt:
         tx = copy(safe_tx)
-        safe = Contract.from_abi('Gnosis Safe', self.address, self.get_contract().abi)
+        safe = Contract.from_abi('Gnosis Safe', self.address, self.contract.abi)
         # Replace pending nonce with the subsequent nonce, this could change the safe_tx_hash
         tx.safe_nonce = safe.nonce()
         # Forge signatures from the needed amount of owners, skip the one which submits the tx


### PR DESCRIPTION
- reordered some of the imports and removed unused ones. or was there a reason the `gnosis.eth` import was so far up top?
- redeclaring `safe` on line 343 should be redundant now, no? eg i would expect this to work:

```
>>> from brownie_safe import BrownieSafe
>>> safe = BrownieSafe('onchainification.eth')
>>> safe.contract.getThreshold()
  File "<console>", line 1, in <module>
  File "./brownie_safe.py", line 85, in __getattr__
    return getattr(self.instance, attr)
AttributeError: 'Contract' object has no attribute 'getThreshold'
```

if so, we could just call `self.contract.nonce()` on line 345 for example, and leave out the redeclaration of `safe`.

funny enough, this does work:

```
>>> safe.contract.all_functions()
[<Function VERSION()>, <Function addOwnerWithThreshold(address,uint256)>, <Function approveHash(bytes32)>, <Function approvedHashes(address,bytes32)>, <Function changeThreshold(uint256)>, <Function checkNSignatures(bytes32,bytes,bytes,uint256)>, <Function checkSignatures(bytes32,bytes,bytes)>, <Function disableModule(address,address)>, <Function domainSeparator()>, <Function enableModule(address)>, <Function encodeTransactionData(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,uint256)>, <Function execTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes)>, <Function execTransactionFromModule(address,uint256,bytes,uint8)>, <Function execTransactionFromModuleReturnData(address,uint256,bytes,uint8)>, <Function getChainId()>, <Function getModulesPaginated(address,uint256)>, <Function getOwners()>, <Function getStorageAt(uint256,uint256)>, <Function getThreshold()>, <Function getTransactionHash(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,uint256)>, <Function isModuleEnabled(address)>, <Function isOwner(address)>, <Function nonce()>, <Function removeOwner(address,address,uint256)>, <Function requiredTxGas(address,uint256,bytes,uint8)>, <Function setFallbackHandler(address)>, <Function setGuard(address)>, <Function setup(address[],uint256,address,bytes,address,address,uint256,address)>, <Function signedMessages(bytes32)>, <Function simulateAndRevert(address,bytes)>, <Function swapOwner(address,address,address)>]
```

this even completely breaks the runtime:

```
>>> vars(safe.contract.instance)
```